### PR TITLE
Switch order of literals to prevent NullPointerException 

### DIFF
--- a/Code/src/minesweeper/Game.java
+++ b/Code/src/minesweeper/Game.java
@@ -547,7 +547,7 @@ public class Game implements MouseListener, ActionListener, WindowListener
                 cellSolution = cells[x][y].getContent();
 
                 // Is the cell still unrevealed
-                if( cellSolution.equals("") ) 
+                if( "".equals(cellSolution) ) 
                 {
                     buttons[x][y].setIcon(null);
                     
@@ -565,7 +565,7 @@ public class Game implements MouseListener, ActionListener, WindowListener
                     }
                     else
                     {
-                        if(cellSolution.equals("0"))
+                        if("0".equals(cellSolution))
                         {
                             buttons[x][y].setText("");                           
                             buttons[x][y].setBackground(Color.lightGray);
@@ -580,7 +580,7 @@ public class Game implements MouseListener, ActionListener, WindowListener
                 }
 
                 // This cell is already flagged!
-                else if( cellSolution.equals("F") ) 
+                else if( "F".equals(cellSolution) ) 
                 {
                     // Is it correctly flagged?
                     if(!cells[x][y].getMine()) 
@@ -770,7 +770,7 @@ public class Game implements MouseListener, ActionListener, WindowListener
     public void actionPerformed(ActionEvent e) {        
         JMenuItem menuItem = (JMenuItem) e.getSource();
 
-        if (menuItem.getName().equals("New Game"))
+        if ("New Game".equals(menuItem.getName()))
         {
             if (playing)
             {
@@ -802,7 +802,7 @@ public class Game implements MouseListener, ActionListener, WindowListener
             }
         }
         
-        else if (menuItem.getName().equals("Exit"))
+        else if ("Exit".equals(menuItem.getName()))
         {
             windowClosing(null);
         }

--- a/Code/src/minesweeper/UI.java
+++ b/Code/src/minesweeper/UI.java
@@ -449,21 +449,21 @@ public class UI extends JFrame
     //---------------------------------------------------------------------//
     public void setTextColor(JButton b)
     {
-        if (b.getText().equals("1"))
+        if ("1".equals(b.getText()))
             b.setForeground(Color.blue);
-        else if (b.getText().equals("2"))
+        else if ("2".equals(b.getText()))
             b.setForeground(new Color(76,153,0));
-        else if (b.getText().equals("3"))
+        else if ("3".equals(b.getText()))
             b.setForeground(Color.red);
-        else if (b.getText().equals("4"))
+        else if ("4".equals(b.getText()))
             b.setForeground(new Color(153,0,0));
-        else if (b.getText().equals("5"))
+        else if ("5".equals(b.getText()))
             b.setForeground(new Color(153,0,153));
-        else if (b.getText().equals("6"))
+        else if ("6".equals(b.getText()))
             b.setForeground(new Color(96,96,96));
-        else if (b.getText().equals("7"))
+        else if ("7".equals(b.getText()))
             b.setForeground(new Color(0,0,102));
-        else if (b.getText().equals("8"))
+        else if ("8".equals(b.getText()))
             b.setForeground(new Color(153,0,76));        
     }
     //------------------------------------------------------------------------//


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-zc%2FMinesweeper-Desktop-Game%7Cc11fcd0c718e9a8e25de97b981a98e79973402a3)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->